### PR TITLE
Only set htmlrewriter conditionally if it doesn't exist in the runtime

### DIFF
--- a/src/endpoint-harness.ts
+++ b/src/endpoint-harness.ts
@@ -1,8 +1,12 @@
 import Router, { Context } from '@qpoint/router';
-import { HTMLRewriter } from 'htmlrewriter';
 import { Queue } from './queue';
 
-(globalThis as any).HTMLRewriter = HTMLRewriter;
+// Ensure this runtime has an HTMLRewriter
+if (!(globalThis as any).HTMLRewriter) {
+  await import('htmlrewriter').then(module => {
+    (globalThis as any).HTMLRewriter = module.HTMLRewriter;
+  });
+}
 
 /**
  * The `EndpointHarness` class is designed for testing Qpoint middleware. It features a router


### PR DESCRIPTION
Many modern runtimes already provide an HTMLRewriter, and we'll want to keep the option to use them when it makes sense. This just ensures the runtime (mostly node) has an HTMLRewriter if it doesn't already exist.